### PR TITLE
Explicit documentation for pure policy limitation and update to event_index signature

### DIFF
--- a/experiments/fllor2/newcomb.ipynb
+++ b/experiments/fllor2/newcomb.ipynb
@@ -131,6 +131,14 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "predictor-accuracy-note",
+   "metadata": {},
+   "source": [
+    "Note: predictor-accuracy learning in `NewcombWorldModel` currently uses a compact right/wrong history, which is only a sufficient statistic for pure policies. For mixed policies, the infradistribution update still applies the immediate observation likelihood to each a-measure's scale, but the persistent predictor-accuracy history is left unchanged. Supporting mixed-policy learning cleanly would require storing policy-conditioned likelihood evidence rather than binary counts."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 5,
    "id": "b191e476",

--- a/ibrl/infrabayesian/infradistribution.py
+++ b/ibrl/infrabayesian/infradistribution.py
@@ -81,7 +81,7 @@ class Infradistribution:
         Update all a-measures upon seeing a certain event using a given reward function
         This is Definition 11 from Basic Inframeasure Theory
         """
-        event = self.world_model.event_index(outcome)
+        event = self.world_model.event_index(outcome, action)
         rf = reward_function[action]
 
         # Expectation values (need to be computed before updating anything)

--- a/ibrl/infrabayesian/world_model.py
+++ b/ibrl/infrabayesian/world_model.py
@@ -32,9 +32,9 @@ class WorldModel(ABC):
         pass
 
     @abstractmethod
-    def event_index(self, outcome: Outcome) -> int:
+    def event_index(self, outcome: Outcome, action: int) -> int:
         """
-        Extract the discrete event index from an outcome.
+        Extract the discrete event index from an outcome and selected action.
         Used by the gluing operator and belief state update.
         """
         pass

--- a/ibrl/infrabayesian/world_models/bernoulli_world_model.py
+++ b/ibrl/infrabayesian/world_models/bernoulli_world_model.py
@@ -80,7 +80,7 @@ class MultiBernoulliWorldModel(WorldModel):
             mixed.coefficients.append(mixed_coefficients)
         return mixed
 
-    def event_index(self, outcome: Outcome) -> int:
+    def event_index(self, outcome: Outcome, action: int) -> int:
         # For Bernoulli bandits reward is the event type, so this mapping is exact.
         return int(round(outcome.reward * (self.num_outcomes - 1)))
 
@@ -93,7 +93,7 @@ class MultiBernoulliWorldModel(WorldModel):
             action: int,
             policy: np.ndarray | None) -> BernoulliWorldModelBeliefState:
         new_state = BernoulliWorldModelBeliefState(state.history.copy())
-        new_state.history[action, self.event_index(outcome)] += 1
+        new_state.history[action, self.event_index(outcome, action)] += 1
         return new_state
 
     def is_initial(self, state: BernoulliWorldModelBeliefState) -> bool:
@@ -106,7 +106,7 @@ class MultiBernoulliWorldModel(WorldModel):
             action: int,
             policy: np.ndarray | None) -> float:
         probs = self._predictive(belief_state.history[action], params.log_probs[action], params.coefficients[action])
-        return float(probs[self.event_index(outcome)])
+        return float(probs[self.event_index(outcome, action)])
 
     def compute_expected_reward(self,
             belief_state: BernoulliWorldModelBeliefState,

--- a/ibrl/infrabayesian/world_models/newcomb_world_model.py
+++ b/ibrl/infrabayesian/world_models/newcomb_world_model.py
@@ -28,6 +28,11 @@ class NewcombWorldModelBeliefState:
     Belief state of Newcomb world model: Histogram of previous observations
         history[0]  Number of times predictor was wrong
         history[1]  Number of times predictor was right
+
+    This compact right/wrong history is only a sufficient statistic for pure
+    policies. For mixed policies, the infradistribution update still applies
+    the immediate observation likelihood to each a-measure's scale, but this
+    persistent predictor-accuracy history is left unchanged.
     """
     history : np.ndarray  # integer array shape (2,)
 
@@ -97,13 +102,10 @@ class NewcombWorldModel(WorldModel):
             action : int,
             policy : np.ndarray):
         new_state = NewcombWorldModelBeliefState(state.history.copy())
-        if np.isclose(policy[action], 1):  # Update only on pure strategies
-            # Updating on mixed strategies would be more complicated, as the
-            # amount of information gained depends on the policy, e.g. uniform
-            # policy -> no information gain because perfect and random
-            # predictor behave identical.
-            # Also, even a random predictor will be correct sometimes. This is
-            # currently not taken into account.
+        if np.isclose(policy[action], 1):
+            # The right/wrong history only supports predictor-accuracy learning
+            # for pure policies. Mixed-policy learning would require storing
+            # policy-conditioned likelihood evidence instead of binary counts.
             new_state.history[int(outcome.observation == action)] += 1
         return new_state
 

--- a/ibrl/infrabayesian/world_models/newcomb_world_model.py
+++ b/ibrl/infrabayesian/world_models/newcomb_world_model.py
@@ -81,17 +81,17 @@ class NewcombWorldModel(WorldModel):
         mixed_coefficients /= mixed_coefficients.sum()  # For numerics
         return NewcombWorldModelParameters(coefficients=mixed_coefficients, log_accuracy=log_accuracy)
 
-    def event_index(self, outcome: Outcome) -> int:
-        indices = []
-        i = outcome.observation            # predicted action
-        for j in range(self.num_actions):  # selected action
-            if np.isclose(outcome.reward, self.reward_matrix[i,j]):
-                indices.append(i*self.num_actions + j)
-        if len(indices) == 0:
+    def event_index(self, outcome: Outcome, action: int) -> int:
+        i = outcome.observation
+        j = action
+        if i is None or not (0 <= i < self.num_actions):
             raise RuntimeError(f"Invalid outcome in Newcomb environment: {outcome}")
-        if len(indices) > 1:
-            raise RuntimeError(f"Ambiguous outcome in Newcomb environment: {outcome}")
-        return indices[0]
+        if not (0 <= j < self.num_actions):
+            raise RuntimeError(f"Invalid action in Newcomb environment: {action}")
+        if not np.isclose(outcome.reward, self.reward_matrix[i,j]):
+            raise RuntimeError(f"Invalid outcome in Newcomb environment: {outcome}")
+        # Events are indexed by flattening the (prediction, action) table row-major.
+        return i*self.num_actions + j
 
     def initial_state(self):
         return NewcombWorldModelBeliefState(history=np.zeros(2, dtype=np.int64))
@@ -121,7 +121,7 @@ class NewcombWorldModel(WorldModel):
         P(outcome | belief_state, params, action) under this hypothesis.
         Returns a scalar in [0, 1].
         """
-        event = self.event_index(outcome)
+        event = self.event_index(outcome, action)
 
         # i: predicted action
         # j: selected action

--- a/tests/test_newcomb_world_model.py
+++ b/tests/test_newcomb_world_model.py
@@ -73,6 +73,25 @@ def test_newcomb_expected_reward_matches_prediction_table_product():
         np.testing.assert_array_equal(actual, expected)
 
 
+def test_newcomb_likelihood_uses_action_when_rewards_are_repeated():
+    """Repeated rewards are valid because observation and selected action define the event."""
+    reward_table = np.array([[0., 0.], [1., 2.]])
+    wm = NewcombWorldModel(reward_table)
+    state = wm.initial_state()
+    params = wm.make_params(predictor_accuracy=0.8)
+    policy = np.array([0.25, 0.75])
+
+    outcome = Outcome(observation=0, reward=reward_table[0, 1])
+
+    assert wm.compute_likelihood(
+        state,
+        outcome,
+        params,
+        action=1,
+        policy=policy,
+    ) == pytest.approx(newcomb_prediction(policy, accuracy=0.8)[0])
+
+
 def test_newcomb_updates_history_only_for_pure_policies():
     """Newcomb belief history records predictor correctness only for pure policies."""
     wm = NewcombWorldModel()


### PR DESCRIPTION
## What does this change?
1. Documented mixed-policy predictor-accuracy limitation: Added source/notebook notes clarifying that NewcombWorldModel only updates its compact right/wrong predictor-accuracy history for pure policies, not mixed policies
2. Fixed Newcomb event indexing with repeated rewards: Changed WorldModel.event_index to accept the selected action, so NewcombWorldModel indexes events by (outcome.observation, action) instead of inferring action from reward. This makes reward matrices with repeated reward values valid. Full test suite passes, including additional test for repeated reward matrix case.

## Where in the codebase?
- [ ] Shared library (`ibrl/`)
- [ ] Experiment (`experiments/`)
- [ ] Project config (`pyproject.toml`, `.gitignore`, `.github/`)

## Related issue or discussion thread
Link to a GitHub issue, Slack/Discord thread or architecture doc section. If no issue exists, briefly explain why this change is needed. Write "N/A" only if truly not applicable.

## If shared library (`ibrl/`):

### How did you verify correctness?
Did you test against a known result? Compare to an existing implementation? Run a specific environment? If you vibe coded, confirm you reviewed the output for correctness and adherence to spec.

### What is the math or theory behind this change?
Briefly explain the relevant formulation. For example: what update rule does this agent use, what distribution does this environment sample from, what property of infrabayesianism does this rely on. Enough for the reviewer to check the code against the theory.

## If experiment (`experiments/`):

Does your experiment directory have a `README.md`? Your README should cover what the experiment is, why you ran it, results and your interpretation.
- [ ] Experiment `README.md` added
