### PR TITLE
Scripts to reproduce paper figures broke with exploration refactor

### DIFF
--- a/experiments/fllor2/ku_demo.py
+++ b/experiments/fllor2/ku_demo.py
@@ -15,6 +15,7 @@ import numpy as np
 
 from ibrl.agents import DiscreteBayesianAgent, InfraBayesianAgent
 from ibrl.environments import BernoulliBanditEnvironment
+from ibrl.exploration import Greedy
 from ibrl.infrabayesian import AMeasure, Infradistribution, MultiBernoulliWorldModel
 from ibrl.simulators import simulate
 
@@ -53,7 +54,7 @@ def classical_agent(agent_probs: tuple[float, float]) -> FixedBeliefBayesianAgen
         p1=agent_probs[0],
         p2=agent_probs[1],
         num_actions=2,
-        epsilon=0.0,
+        exploration_strategy=Greedy(),
     )
 
 
@@ -68,7 +69,6 @@ def ib_agent() -> InfraBayesianAgent:
     ]
     return InfraBayesianAgent(
         num_actions=2,
-        epsilon=0.0,
         hypotheses=[Infradistribution(measures, wm)],
     )
 

--- a/experiments/fllor2/newcomb_accuracy.py
+++ b/experiments/fllor2/newcomb_accuracy.py
@@ -37,7 +37,6 @@ def make_agent(env: NewcombEnvironment, *, predictor_accuracy: float, seed: int)
     hypothesis = Infradistribution([AMeasure(wm.make_params(predictor_accuracy))], wm)
     return InfraBayesianAgent(
         num_actions=2,
-        epsilon=0.0,
         hypotheses=[hypothesis],
         reward_function=wm.agent_reward_matrix(),
         policy_discretisation=5,

--- a/experiments/fllor2/validate_classical.py
+++ b/experiments/fllor2/validate_classical.py
@@ -33,11 +33,10 @@ def make_classical_ib_agent(
     grid = [np.array([1.0 - p, p]) for p in np.linspace(0.0, 1.0, num_hypotheses)]
     params = wm.make_params([grid] * num_actions)
     hypothesis = Infradistribution([AMeasure(params)], world_model=wm)
-    epsilon = kwargs.pop("epsilon", 0.1)
+    kwargs.setdefault("exploration_strategy", EpsilonGreedy(0.1))
     return InfraBayesianAgent(
         num_actions=num_actions,
         hypotheses=[hypothesis],
-        exploration_strategy=EpsilonGreedy(epsilon),
         **kwargs,
     )
 
@@ -54,7 +53,6 @@ def run_validation() -> dict[str, dict[str, dict]]:
         "num_actions": 2,
         "seed": options["seed"] + 0x01234567,
         "verbose": options["verbose"],
-        "epsilon": 0.1,
     }
     envs = {
         r"$p=(0.49,0.51)$": BernoulliBanditEnvironment(probs=[0.49, 0.51], **options),
@@ -66,8 +64,16 @@ def run_validation() -> dict[str, dict[str, dict]]:
     results: dict[str, dict[str, dict]] = {}
     for env_name, env in envs.items():
         agents = {
-            "Bayesian": DiscreteBayesianAgent(**shared, num_hypotheses=5),
-            "Infra-Bayesian": make_classical_ib_agent(**shared, num_hypotheses=5),
+            "Bayesian": DiscreteBayesianAgent(
+                **shared,
+                num_hypotheses=5,
+                exploration_strategy=EpsilonGreedy(0.1),
+            ),
+            "Infra-Bayesian": make_classical_ib_agent(
+                **shared,
+                num_hypotheses=5,
+                exploration_strategy=EpsilonGreedy(0.1),
+            ),
         }
         results[env_name] = {
             agent_name: simulate(env, agent, options, 0x01234567, 0x89ABCDEF)


### PR DESCRIPTION

## What does this change?
When exploration change was merged, it was missing these scripts that reproduce paper figures. Fixing them here to have the updated syntax.


## Where in the codebase?
- [ ] Shared library (`ibrl/`)
- [x] Experiment (`experiments/`)
- [ ] Project config (`pyproject.toml`, `.gitignore`, `.github/`)

## Related issue or discussion thread
Link to a GitHub issue, Slack/Discord thread or architecture doc section. If no issue exists, briefly explain why this change is needed. Write "N/A" only if truly not applicable.

## If shared library (`ibrl/`):

### How did you verify correctness?
Did you test against a known result? Compare to an existing implementation? Run a specific environment? If you vibe coded, confirm you reviewed the output for correctness and adherence to spec.

### What is the math or theory behind this change?
Briefly explain the relevant formulation. For example: what update rule does this agent use, what distribution does this environment sample from, what property of infrabayesianism does this rely on. Enough for the reviewer to check the code against the theory.

## If experiment (`experiments/`):

Does your experiment directory have a `README.md`? Your README should cover what the experiment is, why you ran it, results and your interpretation.
- [ ] Experiment `README.md` added
